### PR TITLE
Properly cache icons

### DIFF
--- a/fedmsg_notify/daemon.py
+++ b/fedmsg_notify/daemon.py
@@ -245,6 +245,7 @@ class FedmsgNotifyService(dbus.service.Object, fedmsg.consumers.FedmsgConsumer):
         checksum = self.hash_file(filename)
         if checksum in cache:
             cache[icon_url] = cache[checksum]
+            os.unlink(filename)
         else:
             cache[icon_url] = cache[checksum] = filename
 


### PR DESCRIPTION
We should improve how we currently handle icon caching, ideally by leveraging the tempfile handling of systemd. :recycle:
